### PR TITLE
fixed a little bug in useListenMessages.js hook

### DIFF
--- a/frontend/src/hooks/useListenMessages.js
+++ b/frontend/src/hooks/useListenMessages.js
@@ -7,14 +7,17 @@ import notificationSound from "../assets/sounds/notification.mp3";
 
 const useListenMessages = () => {
 	const { socket } = useSocketContext();
-	const { messages, setMessages } = useConversation();
+	const { messages, setMessages, selectedConversation } = useConversation();
 
 	useEffect(() => {
 		socket?.on("newMessage", (newMessage) => {
-			newMessage.shouldShake = true;
-			const sound = new Audio(notificationSound);
-			sound.play();
-			setMessages([...messages, newMessage]);
+			// add the newMessage to the messages array only if it is sent by the selectedConversation user id
+			if (selectedConversation?._id === newMessage.senderId) {
+				newMessage.shouldShake = true;
+				const sound = new Audio(notificationSound);
+				sound.play();
+				setMessages([...messages, newMessage]);
+			}
 		});
 
 		return () => socket?.off("newMessage");


### PR DESCRIPTION
I checked that if a person A is online(i.e. his socket.io id is online), and he has opened the chat with person B, then at that time if any person C sends him a message then it gets rendered in the person A and B chat conversation. Because useListenMessages.js hook listens to all the messages sent to person A's socket.io id... So to prevent this while we have a selected conversation, we should add a if statement to check if the newMessage sent to our socket.io id is sent by the person we are chatting with right now, so others message will not be rendered during your ongoing chat with a person.